### PR TITLE
Limit volume size of submissions

### DIFF
--- a/scripts/run_docker.py
+++ b/scripts/run_docker.py
@@ -143,7 +143,7 @@ def main(syn, args):
     # create a local volume and set size limit
     output_volume = client.volumes.create(name=args.submissionid,
                                           driver='local',
-                                          driver_opts={"size": "100m"})
+                                          driver_opts={"size": "80g"})
     # set volumes used to mount
     input_mount = [input_dir, "input"]
     output_mount = [args.submissionid, "output"]

--- a/scripts/run_docker.py
+++ b/scripts/run_docker.py
@@ -143,7 +143,7 @@ def main(syn, args):
     # create a local volume and set size limit
     output_volume = client.volumes.create(name=args.submissionid,
                                           driver='local',
-                                          driver_opts={"size": "80g"})
+                                          driver_opts={"size": "100m"})
     # set volumes used to mount
     input_mount = [input_dir, "input"]
     output_mount = [args.submissionid, "output"]

--- a/scripts/run_docker.py
+++ b/scripts/run_docker.py
@@ -143,7 +143,7 @@ def main(syn, args):
     print("mounting volumes")
     # create a local volume used to mount to /output
     output_volume = client.volumes.create(name="args.submissionid",
-                                          driver='local', driver_opts={"size": "100m"})
+                                          driver='local', driver_opts={"size": "80g"})
     # These are the locations on the docker that you want your mounted
     # volumes to be + permissions in docker (ro, rw)
     # It has to be in this format


### PR DESCRIPTION
- fixes #23 
The idea here is to limit the size of submission. This pr is to create a volume (`output_volume`) first with limited size and copy over the prediction files to the working dir of run docker. If the volume usage is beyond the size limit, the model will break - error should be in the model log file.

Also, before the model failed, the output volume is not cleaned up until successful submissions. Now, the volume can be easily removed after failure.

```console
> docker inspect  9729442

        "Mounts": [
            {
                "Type": "bind",
                "Source": "/home/ec2-user/challenge-data/downsampled/scrna-synthetic",
                "Destination": "/input",
                "Mode": "ro",
                "RW": false,
                "Propagation": "rprivate"
            },
            {
                "Type": "volume",
                "Name": "9729442",
                "Source": "/var/lib/docker/volumes/args.submissionid/_data",
                "Destination": "/output",
                "Driver": "local",
                "Mode": "rw",
                "RW": true,
                "Propagation": ""
            }
```